### PR TITLE
Fix vision_msgs usage in object tracker

### DIFF
--- a/src/trackor/trackor/object_detect.py
+++ b/src/trackor/trackor/object_detect.py
@@ -1,10 +1,14 @@
 import rclpy
 from rclpy.node import Node
-from vision_msgs.msg import Detection2DArray, Detection2D, ObjectHypothesisWithPose
-from std_msgs.msg import Header
+from vision_msgs.msg import (
+    Detection2DArray,
+    Detection2D,
+    ObjectHypothesis,
+    ObjectHypothesisWithPose,
+)
+from geometry_msgs.msg import PoseWithCovariance
 from trackor.sort import Sort
 import numpy as np
-from geometry_msgs.msg import Pose2D
 
 class ObjectTrackerNode(Node):
     def __init__(self):
@@ -55,16 +59,26 @@ class ObjectTrackerNode(Node):
         for track in tracks:
             x1, y1, x2, y2, track_id = track
             bbox = Detection2D()
-            bbox.bbox.center.position.x = float((x1 + x2) / 2)
-            bbox.bbox.center.position.y = float((y1 + y2) / 2)
+            bbox.bbox.center.x = float((x1 + x2) / 2)
+            bbox.bbox.center.y = float((y1 + y2) / 2)
+            bbox.bbox.center.theta = 0.0
             bbox.bbox.size_x = float(x2 - x1)
             bbox.bbox.size_y = float(y2 - y1)
 
-            hyp = ObjectHypothesisWithPose()
-            hyp.id = int(track_id)
-            hyp.score = 1.0  # 跟踪置信度可设为 1.0 或从检测中继承
+            hypothesis = ObjectHypothesis()
+            hypothesis.id = int(track_id)
+            hypothesis.score = 1.0  # 跟踪置信度可设为 1.0 或从检测中继承
 
-            bbox.results.append(hyp)
+            ohwp = ObjectHypothesisWithPose()
+            ohwp.hypothesis = hypothesis
+
+            pwc = PoseWithCovariance()
+            pwc.pose.position.x = bbox.bbox.center.x
+            pwc.pose.position.y = bbox.bbox.center.y
+            pwc.pose.orientation.w = 1.0
+            ohwp.pose = pwc
+
+            bbox.results.append(ohwp)
             tracked_msg.detections.append(bbox)
 
         self.publisher.publish(tracked_msg)


### PR DESCRIPTION
## Summary
- use vision_msgs Pose2D fields when publishing tracked boxes
- build ObjectHypothesisWithPose correctly for tracker outputs

## Testing
- `colcon test --packages-select trackor` *(fails: command not found)*
- `pytest src/trackor/test/test_flake8.py` *(fails: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68a9a0e4e5b08321bd1be1044845f83b