### PR TITLE
Fix vision_msgs Pose2D usage in detection and tracker

### DIFF
--- a/src/detect/detect/mask_detect.py
+++ b/src/detect/detect/mask_detect.py
@@ -112,9 +112,9 @@ class YoloV5OnnxSubscriber(Node):
             detection = Detection2D()
 
             x1, y1, x2, y2 = box
-            center2d = Pose2D()  # ← 这里必须是 vision_msgs.Pose2D
-            center2d.x = (x1 + x2) / 2.0
-            center2d.y = (y1 + y2) / 2.0
+            center2d = Pose2D()
+            center2d.position.x = (x1 + x2) / 2.0
+            center2d.position.y = (y1 + y2) / 2.0
             center2d.theta = 0.0
             detection.bbox.center = center2d
 
@@ -130,8 +130,8 @@ class YoloV5OnnxSubscriber(Node):
             ohwp.hypothesis = hyp
 
             pwc = PoseWithCovariance()
-            pwc.pose.position.x = center2d.x
-            pwc.pose.position.y = center2d.y
+            pwc.pose.position.x = center2d.position.x
+            pwc.pose.position.y = center2d.position.y
             pwc.pose.position.z = 0.0
             pwc.pose.orientation.w = 1.0
             ohwp.pose = pwc

--- a/src/trackor/trackor/object_detect.py
+++ b/src/trackor/trackor/object_detect.py
@@ -1,10 +1,14 @@
 import rclpy
 from rclpy.node import Node
-from vision_msgs.msg import Detection2DArray, Detection2D, ObjectHypothesisWithPose
-from std_msgs.msg import Header
+from vision_msgs.msg import (
+    Detection2DArray,
+    Detection2D,
+    ObjectHypothesis,
+    ObjectHypothesisWithPose,
+)
+from geometry_msgs.msg import PoseWithCovariance
 from trackor.sort import Sort
 import numpy as np
-from geometry_msgs.msg import Pose2D
 
 class ObjectTrackerNode(Node):
     def __init__(self):
@@ -30,8 +34,8 @@ class ObjectTrackerNode(Node):
         dets = []
 
         for det in msg.detections:
-            x = det.bbox.center.x
-            y = det.bbox.center.y
+            x = det.bbox.center.position.x
+            y = det.bbox.center.position.y
             w = det.bbox.size_x
             h = det.bbox.size_y
             score = det.results[0].score if det.results else 1.0
@@ -57,14 +61,24 @@ class ObjectTrackerNode(Node):
             bbox = Detection2D()
             bbox.bbox.center.position.x = float((x1 + x2) / 2)
             bbox.bbox.center.position.y = float((y1 + y2) / 2)
+            bbox.bbox.center.theta = 0.0
             bbox.bbox.size_x = float(x2 - x1)
             bbox.bbox.size_y = float(y2 - y1)
 
-            hyp = ObjectHypothesisWithPose()
-            hyp.id = int(track_id)
-            hyp.score = 1.0  # 跟踪置信度可设为 1.0 或从检测中继承
+            hypothesis = ObjectHypothesis()
+            hypothesis.id = int(track_id)
+            hypothesis.score = 1.0  # 跟踪置信度可设为 1.0 或从检测中继承
 
-            bbox.results.append(hyp)
+            ohwp = ObjectHypothesisWithPose()
+            ohwp.hypothesis = hypothesis
+
+            pwc = PoseWithCovariance()
+            pwc.pose.position.x = bbox.bbox.center.position.x
+            pwc.pose.position.y = bbox.bbox.center.position.y
+            pwc.pose.orientation.w = 1.0
+            ohwp.pose = pwc
+
+            bbox.results.append(ohwp)
             tracked_msg.detections.append(bbox)
 
         self.publisher.publish(tracked_msg)


### PR DESCRIPTION
## Summary
- use Pose2D position fields when building mask detection messages
- read and populate detection centers via Pose2D.position in object tracker

## Testing
- `colcon test --packages-select trackor` *(fails: command not found)*
- `pytest src/trackor/test/test_flake8.py` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68a9a0e4e5b08321bd1be1044845f83b