### PR TITLE
Integrate DeepSORT tracking

### DIFF
--- a/src/trackor/package.xml
+++ b/src/trackor/package.xml
@@ -8,6 +8,7 @@
   <license>TODO: License declaration</license>
 
   <depend>rclpy</depend>
+  <exec_depend>deep-sort-realtime</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/trackor/setup.py
+++ b/src/trackor/setup.py
@@ -11,7 +11,7 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'deep-sort-realtime'],
     zip_safe=True,
     maintainer='wanglonglong',
     maintainer_email='wanglonglong02@gmail.com',


### PR DESCRIPTION
## Summary
- swap out SORT for DeepSORT and wire tracker to use appearance features
- add deep-sort-realtime dependency in setup.py and package.xml

## Testing
- `python -m py_compile src/trackor/trackor/object_detect.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc320d3c83219691012298d26006