### PR TITLE
Filter detections in lower image region

### DIFF
--- a/src/detect/detect/mask_detect.py
+++ b/src/detect/detect/mask_detect.py
@@ -221,7 +221,7 @@ class YoloV5OnnxSubscriber(Node):
 
             # 过滤图像下部区域的检测结果
             h = frame.shape[0]
-            ignore_ratio = 0.2
+            ignore_ratio = 0.25
             filtered = []
             for box, score, cls in zip(boxes, scores, class_ids):
                 if box[1] > h * (1 - ignore_ratio):

--- a/src/detect/detect/mask_detect.py
+++ b/src/detect/detect/mask_detect.py
@@ -218,6 +218,19 @@ class YoloV5OnnxSubscriber(Node):
             img_input, img_resized = self.preprocess(frame)
             outputs = self.session.run(None, {self.input_name: img_input})
             boxes, scores, class_ids = self.postprocess(outputs, img_resized.shape, orig_shape)
+
+            # 过滤图像下部区域的检测结果
+            h = frame.shape[0]
+            ignore_ratio = 0.2
+            filtered = []
+            for box, score, cls in zip(boxes, scores, class_ids):
+                if box[1] > h * (1 - ignore_ratio):
+                    continue
+                filtered.append((box, score, cls))
+            boxes, scores, class_ids = (
+                map(list, zip(*filtered)) if filtered else ([], [], [])
+            )
+
             draw_img = self.draw_detections(frame.copy(), boxes, scores, class_ids)
             if hasattr(self, 'writer'):
                 self.writer.write(draw_img)


### PR DESCRIPTION
## Summary
- Ignore detections whose upper boundary falls within the bottom 20% of the frame

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile src/detect/detect/mask_detect.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad36158c048321971f25bf337bd3d2