### PR TITLE
Enable CUDA provider for ONNX Runtime

### DIFF
--- a/src/detect/detect/mask_detect.py
+++ b/src/detect/detect/mask_detect.py
@@ -62,8 +62,13 @@ class YoloV5OnnxSubscriber(Node):
 
         # 加载 ONNX 模型
         try:
-            self.session = ort.InferenceSession(model_path, providers=['CPUExecutionProvider'])
+            self.session = ort.InferenceSession(
+                model_path, providers=['CUDAExecutionProvider', 'CPUExecutionProvider']
+            )
             self.get_logger().info(f'ONNX 模型加载成功: {model_path}')
+            self.get_logger().info(
+                f"ONNX Runtime providers: {self.session.get_providers()}"
+            )
         except Exception as e:
             self.get_logger().fatal(f'ONNX 模型加载失败: {str(e)}')
             sys.exit(1)


### PR DESCRIPTION
## Summary
- Enable CUDA and CPU execution providers when loading ONNX model
- Log available ONNX Runtime providers for debugging

## Testing
- `pip install onnxruntime-gpu` *(fails: Could not find a version that satisfies the requirement onnxruntime-gpu)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*
- `python src/detect/detect/mask_detect.py` *(fails: ModuleNotFoundError: No module named 'rclpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ad43c422c88321aa46d55c5c9451ce